### PR TITLE
Added repoAlias variable to allow mismatched repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Open in Sourcegraph
 
 ## Overview
+This repo was forked from https://github.com/zacharysnewman/open-in-sourcegraph to add a few features.
 
 **Open in Sourcegraph** is a Visual Studio Code extension that allows you to quickly open files from your project directly in Sourcegraph. With a simple right-click, you can navigate to the corresponding file in your organization's Sourcegraph instance.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The extension can be customized through the following settings:
 - **Default:** "your-base-path"
 - **Description:** The base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
 
+### `openInSourcegraph.repositoryAlias`
+- **Type:** `string`
+- **Default:** ""
+- **Description:** "Optional: If your repository's name on sourcegraph is different from the name on your local environment, you may need to set this variable to the sourcegraph path."
+
 ## Example Configuration
 
 You should configure the extension settings as follows:

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
           "type": "string",
           "default": "your-base-path",
           "description": "The base path used in the Sourcegraph URL."
+        },
+        "openInSourcegraph.repoAlias": {
+          "type": "string",
+          "default": "",
+          "description": "Optional: The repository alias to use in the Sourcegraph URL. If left blank, the repository name will be used."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,10 @@ export function activate(context: vscode.ExtensionContext) {
         "your-subdomain"
       );
       const basePath = config.get<string>("basePath", "your-base-path");
-
+      
       // Extract repository name from workspace folder
-      const repoName = workspaceFolder.name;
+      const repoAlias = config.get<string>("repoAlias", "");
+      const repoName = repoAlias !== "" ? repoAlias : workspaceFolder.name;
 
       // Get the file path relative to the repository root
       const relativeFilePath = path.relative(
@@ -31,8 +32,11 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       // Construct the Sourcegraph URL
-      const sourceGraphUrl = `https://${subdomain}.sourcegraph.com/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
 
+      // If the subdomain ends in a .com or similar domain ending, do not append .sourcegraph.com
+      const suffixes = [".net", ".com", ".org"];
+      const subdomainString = suffixes.some(suffix => subdomain.endsWith(suffix)) ? subdomain : `${subdomain}.sourcegraph.com`;
+      const sourceGraphUrl = `https://${subdomainString}/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
       // Debugging: log the constructed URL
       console.log("SourceGraph URL:", sourceGraphUrl);
 


### PR DESCRIPTION
Some small amendments to make this usable for my use case. We use a nonstandard scheme where we
1. prefix `service-` to the front of our repositories, so instead of `foo` it would be `service-foo` on sourcegraph
2. have our own sourcegraph URL, so instead of `abc-custom-url.sourcegraph.com` it's `sourcegraph.build.ue1.abc-custom-url.net`. I added a line to selectively not append the `sourcegraph.com` if the `subdomain` field already includes a domain ending, but I'm not sure if that would break any existing use cases.