### PR TITLE
Fix fsPath crash and add support for self-hosted Sourcegraph instances

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+When making changes to `src/extension.ts` or `package.json` that affect configuration settings, commands, or behavior described in `README.md`, update the README to reflect those changes as part of the same commit.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Features
 
 - **Quick Access:** Open any file in Sourcegraph directly from VS Code.
-- **Customizable Settings:** Configure the Sourcegraph subdomain and base path to match your project's structure.
+- **Customizable Settings:** Configure the Sourcegraph instance URL and optional base path to match your project's structure.
 - **Seamless Integration:** Integrates with the VS Code explorer context menu for easy access.
 
 ## Installation
@@ -26,59 +26,62 @@
    - Search for **Open in Sourcegraph** to find the extension's settings.
    - Set the following configuration options:
 
-     - **Sourcegraph Subdomain (`openInSourcegraph.sourcegraphSubdomain`):**
+     - **Instance URL (`openInSourcegraph.instanceUrl`):**
 
-       - The subdomain of your Sourcegraph instance (e.g., "company").
+       - The full URL of your Sourcegraph instance (e.g., `https://sourcegraph.mycompany.com`).
 
-     - **Base Path (`openInSourcegraph.basePath`):**
+     - **Base Path (`openInSourcegraph.basePath`):** _(optional)_
 
-       - The base path used in the Sourcegraph URL (e.g., "code.company.com/path").
+       - An optional base path inserted between the instance URL and the repository name (e.g., `code.company.com/path`).
 
 2. **Using the Extension:**
 
-   - In the VS Code explorer, right-click on a file.
-   - Select **Open in Sourcegraph** from the context menu.
+   - In the VS Code explorer, right-click on a file and select **Open in Sourcegraph**, or
+   - Open a file in the editor and run **Open in Sourcegraph** from the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
    - The corresponding file will open in your default web browser via Sourcegraph.
 
 ## Configuration Options
 
-The extension can be customized through the following settings:
-
-### `openInSourcegraph.sourcegraphSubdomain`
+### `openInSourcegraph.instanceUrl`
 
 - **Type:** `string`
-- **Default:** "your-subdomain"
-- **Description:** The subdomain of your Sourcegraph instance. For example, if your Sourcegraph URL is `https://company.sourcegraph.com`, set this to "company".
+- **Default:** `"https://sourcegraph.com"`
+- **Description:** The full URL of your Sourcegraph instance. Use this for both Sourcegraph Cloud and self-hosted instances.
 
 ### `openInSourcegraph.basePath`
 
 - **Type:** `string`
-- **Default:** "your-base-path"
-- **Description:** The base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
+- **Default:** `""`
+- **Description:** An optional base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
 
 ## Example Configuration
 
-You should configure the extension settings as follows:
+### Sourcegraph Cloud
 
-- **Sourcegraph Subdomain:**
+- **Instance URL:** `https://sourcegraph.com`
+- **Base Path:** _(leave empty)_
 
-  "company"
-
-- **Base Path:**
-
-  "code.company.com/path"
-
-With these settings, the extension constructs the Sourcegraph URL as:
-
+Constructs:
 ```
-https://company.sourcegraph.com/code.company.com/path/<workspace-folder>/-/blob/<relativeFilePath>
+https://sourcegraph.com/<workspace-folder>/-/blob/<relativeFilePath>
+```
+
+### Self-hosted Sourcegraph
+
+- **Instance URL:** `https://sourcegraph.mycompany.com`
+- **Base Path:** `code.company.com/path`
+
+Constructs:
+```
+https://sourcegraph.mycompany.com/code.company.com/path/<workspace-folder>/-/blob/<relativeFilePath>
 ```
 
 ## Troubleshooting
 
 - **Incorrect URL Structure:**
 
-  - Double-check your `sourcegraphSubdomain` and `basePath` settings to ensure they match your organization's Sourcegraph URL structure.
+  - Ensure `instanceUrl` is the full URL including `https://` and no trailing slash.
+  - Leave `basePath` empty if your Sourcegraph instance doesn't require one.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Features
 
 - **Quick Access:** Open any file in Sourcegraph directly from VS Code.
-- **Customizable Settings:** Configure the Sourcegraph subdomain and base path to match your project's structure.
+- **Customizable Settings:** Configure the Sourcegraph instance URL and optional base path to match your project's structure.
 - **Seamless Integration:** Integrates with the VS Code explorer context menu for easy access.
 
 ## Installation
@@ -27,35 +27,33 @@ Or search for **"Open in Sourcegraph"** in your editor's Extensions panel.
    - Search for **Open in Sourcegraph** to find the extension's settings.
    - Set the following configuration options:
 
-     - **Sourcegraph Subdomain (`openInSourcegraph.sourcegraphSubdomain`):**
+     - **Instance URL (`openInSourcegraph.instanceUrl`):**
 
-       - The subdomain of your Sourcegraph instance (e.g., "company").
+       - The full URL of your Sourcegraph instance (e.g., `https://sourcegraph.mycompany.com`).
 
-     - **Base Path (`openInSourcegraph.basePath`):**
+     - **Base Path (`openInSourcegraph.basePath`):** _(optional)_
 
-       - The base path used in the Sourcegraph URL (e.g., "code.company.com/path").
+       - An optional base path inserted between the instance URL and the repository name (e.g., `code.company.com/path`).
 
 2. **Using the Extension:**
 
-   - In the VS Code explorer, right-click on a file.
-   - Select **Open in Sourcegraph** from the context menu.
+   - In the VS Code explorer, right-click on a file and select **Open in Sourcegraph**, or
+   - Open a file in the editor and run **Open in Sourcegraph** from the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
    - The corresponding file will open in your default web browser via Sourcegraph.
 
 ## Configuration Options
 
-The extension can be customized through the following settings:
-
-### `openInSourcegraph.sourcegraphSubdomain`
+### `openInSourcegraph.instanceUrl`
 
 - **Type:** `string`
-- **Default:** "your-subdomain"
-- **Description:** The subdomain of your Sourcegraph instance. For example, if your Sourcegraph URL is `https://company.sourcegraph.com`, set this to "company".
+- **Default:** `"https://sourcegraph.com"`
+- **Description:** The full URL of your Sourcegraph instance. Use this for both Sourcegraph Cloud and self-hosted instances.
 
 ### `openInSourcegraph.basePath`
 
 - **Type:** `string`
-- **Default:** "your-base-path"
-- **Description:** The base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
+- **Default:** `""`
+- **Description:** An optional base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
 
 ### `openInSourcegraph.repoAlias`
 
@@ -65,27 +63,32 @@ The extension can be customized through the following settings:
 
 ## Example Configuration
 
-You should configure the extension settings as follows:
+### Sourcegraph Cloud
 
-- **Sourcegraph Subdomain:**
+- **Instance URL:** `https://sourcegraph.com`
+- **Base Path:** _(leave empty)_
 
-  "company"
-
-- **Base Path:**
-
-  "code.company.com/path"
-
-With these settings, the extension constructs the Sourcegraph URL as:
-
+Constructs:
 ```
-https://company.sourcegraph.com/code.company.com/path/<workspace-folder>/-/blob/<relativeFilePath>
+https://sourcegraph.com/<workspace-folder>/-/blob/<relativeFilePath>
+```
+
+### Self-hosted Sourcegraph
+
+- **Instance URL:** `https://sourcegraph.mycompany.com`
+- **Base Path:** `code.company.com/path`
+
+Constructs:
+```
+https://sourcegraph.mycompany.com/code.company.com/path/<workspace-folder>/-/blob/<relativeFilePath>
 ```
 
 ## Troubleshooting
 
 - **Incorrect URL Structure:**
 
-  - Double-check your `sourcegraphSubdomain` and `basePath` settings to ensure they match your organization's Sourcegraph URL structure.
+  - Ensure `instanceUrl` is the full URL including `https://` and no trailing slash.
+  - Leave `basePath` empty if your Sourcegraph instance doesn't require one.
 
 ## Contributors
 

--- a/package.json
+++ b/package.json
@@ -58,15 +58,15 @@
       "type": "object",
       "title": "Open in Sourcegraph Configuration",
       "properties": {
-        "openInSourcegraph.sourcegraphSubdomain": {
+        "openInSourcegraph.instanceUrl": {
           "type": "string",
-          "default": "your-subdomain",
-          "description": "The Sourcegraph subdomain for your organization."
+          "default": "https://sourcegraph.com",
+          "description": "The full URL of your Sourcegraph instance (e.g., 'https://sourcegraph.mycompany.com')."
         },
         "openInSourcegraph.basePath": {
           "type": "string",
-          "default": "your-base-path",
-          "description": "The base path used in the Sourcegraph URL."
+          "default": "",
+          "description": "Optional base path inserted between the instance URL and repository name (e.g., 'code.company.com/path')."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -58,15 +58,15 @@
       "type": "object",
       "title": "Open in Sourcegraph Configuration",
       "properties": {
-        "openInSourcegraph.sourcegraphSubdomain": {
+        "openInSourcegraph.instanceUrl": {
           "type": "string",
-          "default": "your-subdomain",
-          "description": "The Sourcegraph subdomain for your organization."
+          "default": "https://sourcegraph.com",
+          "description": "The full URL of your Sourcegraph instance (e.g., 'https://sourcegraph.mycompany.com')."
         },
         "openInSourcegraph.basePath": {
           "type": "string",
-          "default": "your-base-path",
-          "description": "The base path used in the Sourcegraph URL."
+          "default": "",
+          "description": "Optional base path inserted between the instance URL and repository name (e.g., 'code.company.com/path')."
         },
         "openInSourcegraph.repoAlias": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,13 @@ export function activate(context: vscode.ExtensionContext) {
       );
       const basePath = config.get<string>("basePath", "");
 
+      if (!instanceUrl.trim()) {
+        vscode.window.showErrorMessage(
+          "Open in Sourcegraph: instanceUrl is not configured. Please set it in your settings."
+        );
+        return;
+      }
+
       // Extract repository name from workspace folder
       const repoName = workspaceFolder.name;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,15 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "openInSourcegraph.open",
     (uri: vscode.Uri) => {
-      const filePath = uri.fsPath;
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+      const resolvedUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+
+      if (!resolvedUri) {
+        vscode.window.showErrorMessage("No file is currently open.");
+        return;
+      }
+
+      const filePath = resolvedUri.fsPath;
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(resolvedUri);
 
       if (!workspaceFolder) {
         vscode.window.showErrorMessage("Workspace folder not found.");
@@ -15,11 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Read settings from configuration
       const config = vscode.workspace.getConfiguration("openInSourcegraph");
-      const subdomain = config.get<string>(
-        "sourcegraphSubdomain",
-        "your-subdomain"
+      const instanceUrl = config.get<string>(
+        "instanceUrl",
+        "https://sourcegraph.com"
       );
-      const basePath = config.get<string>("basePath", "your-base-path");
+      const basePath = config.get<string>("basePath", "");
 
       // Extract repository name from workspace folder
       const repoName = workspaceFolder.name;
@@ -31,7 +38,11 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       // Construct the Sourcegraph URL
-      const sourceGraphUrl = `https://${subdomain}.sourcegraph.com/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
+      const base = instanceUrl.replace(/\/$/, "");
+      const pathParts = [basePath, repoName, "-/blob", relativeFilePath]
+        .filter(Boolean)
+        .join("/");
+      const sourceGraphUrl = `${base}/${pathParts}`;
 
       // Debugging: log the constructed URL
       console.log("SourceGraph URL:", sourceGraphUrl);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,13 @@ export function activate(context: vscode.ExtensionContext) {
       );
       const basePath = config.get<string>("basePath", "");
 
+      if (!instanceUrl.trim()) {
+        vscode.window.showErrorMessage(
+          "Open in Sourcegraph: instanceUrl is not configured. Please set it in your settings."
+        );
+        return;
+      }
+
       // Extract repository name from workspace folder
       const repoAlias = config.get<string>("repoAlias", "");
       const repoName = repoAlias !== "" ? repoAlias : workspaceFolder.name;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,15 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "openInSourcegraph.open",
     (uri: vscode.Uri) => {
-      const filePath = uri.fsPath;
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+      const resolvedUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+
+      if (!resolvedUri) {
+        vscode.window.showErrorMessage("No file is currently open.");
+        return;
+      }
+
+      const filePath = resolvedUri.fsPath;
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(resolvedUri);
 
       if (!workspaceFolder) {
         vscode.window.showErrorMessage("Workspace folder not found.");
@@ -15,12 +22,12 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Read settings from configuration
       const config = vscode.workspace.getConfiguration("openInSourcegraph");
-      const subdomain = config.get<string>(
-        "sourcegraphSubdomain",
-        "your-subdomain"
+      const instanceUrl = config.get<string>(
+        "instanceUrl",
+        "https://sourcegraph.com"
       );
-      const basePath = config.get<string>("basePath", "your-base-path");
-      
+      const basePath = config.get<string>("basePath", "");
+
       // Extract repository name from workspace folder
       const repoAlias = config.get<string>("repoAlias", "");
       const repoName = repoAlias !== "" ? repoAlias : workspaceFolder.name;
@@ -32,13 +39,11 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       // Construct the Sourcegraph URL
-
-      // If the subdomain ends in a .com or similar domain ending, do not append .sourcegraph.com
-      const suffixes = [".net", ".com", ".org"];
-      const subdomainString = suffixes.some(suffix => subdomain.endsWith(suffix)) ? subdomain : `${subdomain}.sourcegraph.com`;
-      const sourceGraphUrl = `https://${subdomainString}/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
-      // Debugging: log the constructed URL
-      console.log("SourceGraph URL:", sourceGraphUrl);
+      const base = instanceUrl.replace(/\/$/, "");
+      const pathParts = [basePath, repoName, "-/blob", relativeFilePath]
+        .filter(Boolean)
+        .join("/");
+      const sourceGraphUrl = `${base}/${pathParts}`;
 
       // Open the URL in the default browser
       vscode.env.openExternal(vscode.Uri.parse(sourceGraphUrl));


### PR DESCRIPTION
- Guard against undefined uri (command palette invocation) by falling
  back to the active editor's document URI
- Replace sourcegraphSubdomain setting with instanceUrl to support
  arbitrary self-hosted Sourcegraph instances
- Update basePath default to empty string (optional field)
- Update README to reflect new settings and document both invocation methods

Fixes: https://github.com/zacharysnewman/open-in-sourcegraph/issues/1

https://claude.ai/code/session_01EjpoExzDWPaFvSe8Ho5LXx