### PR TITLE
Add repoAlias setting and smart subdomain detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Open in Sourcegraph
 
 ## Overview
+This repo was forked from https://github.com/zacharysnewman/open-in-sourcegraph to add a few features.
 
 **Open in Sourcegraph** is a Visual Studio Code extension that allows you to quickly open files from your project directly in Sourcegraph. With a simple right-click, you can navigate to the corresponding file in your organization's Sourcegraph instance.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The extension can be customized through the following settings:
 - **Default:** "your-base-path"
 - **Description:** The base path in the Sourcegraph URL after the domain. This may include paths specific to your organization's Sourcegraph setup.
 
+### `openInSourcegraph.repositoryAlias`
+- **Type:** `string`
+- **Default:** ""
+- **Description:** "Optional: If your repository's name on sourcegraph is different from the name on your local environment, you may need to set this variable to the sourcegraph path."
+
 ## Example Configuration
 
 You should configure the extension settings as follows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-in-sourcegraph",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-in-sourcegraph",
-      "version": "0.0.4",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.8",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -174,13 +174,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -801,9 +815,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1108,9 +1122,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1313,9 +1327,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3078,9 +3092,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-in-sourcegraph",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-in-sourcegraph",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-in-sourcegraph",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-in-sourcegraph",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-in-sourcegraph-2",
   "displayName": "Open in Sourcegraph 2",
   "description": "Quickly open files in Sourcegraph from VS Code. Forked from Zach Newman's original extension to add support for custom base paths and repository aliases.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "aleggs",
   "engines": {
     "vscode": "^1.94.0"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "open-in-sourcegraph",
   "displayName": "Open in Sourcegraph",
   "description": "Quickly open files in Sourcegraph from VS Code",
-  "version": "0.0.4",
-  "publisher": "zacharysnewman",
+  "version": "1.0.0",
+  "publisher": "aleggs",
   "engines": {
     "vscode": "^1.94.0"
   },
@@ -20,7 +20,7 @@
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "login": "npx vsce login zacharysnewman",
+    "login": "npx vsce login aleggs",
     "publish": "npx vsce publish minor",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
@@ -31,12 +31,12 @@
   "activationEvents": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/zacharysnewman/open-in-sourcegraph.git"
+    "url": "https://github.com/aleggs/open-in-sourcegraph.git"
   },
   "bugs": {
-    "url": "https://github.com/zacharysnewman/open-in-sourcegraph/issues"
+    "url": "https://github.com/aleggs/open-in-sourcegraph/issues"
   },
-  "homepage": "https://github.com/zacharysnewman/open-in-sourcegraph#readme",
+  "homepage": "https://github.com/aleggs/open-in-sourcegraph#readme",
   "license": "MIT",
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "open-in-sourcegraph",
-  "displayName": "Open in Sourcegraph",
-  "description": "Quickly open files in Sourcegraph from VS Code",
+  "name": "open-in-sourcegraph-2",
+  "displayName": "Open in Sourcegraph 2",
+  "description": "Quickly open files in Sourcegraph from VS Code. Forked from Zach Newman's original extension to add support for custom base paths and repository aliases.",
   "version": "1.0.0",
   "publisher": "aleggs",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
           "type": "string",
           "default": "your-base-path",
           "description": "The base path used in the Sourcegraph URL."
+        },
+        "openInSourcegraph.repoAlias": {
+          "type": "string",
+          "default": "",
+          "description": "Optional: The repository alias to use in the Sourcegraph URL. If left blank, the repository name will be used."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-in-sourcegraph-2",
   "displayName": "Open in Sourcegraph 2",
   "description": "Quickly open files in Sourcegraph from VS Code. Forked from Zach Newman's original extension to add support for custom base paths and repository aliases.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "aleggs",
   "engines": {
     "vscode": "^1.94.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,10 @@ export function activate(context: vscode.ExtensionContext) {
         "your-subdomain"
       );
       const basePath = config.get<string>("basePath", "your-base-path");
-
+      
       // Extract repository name from workspace folder
-      const repoName = workspaceFolder.name;
+      const repoAlias = config.get<string>("repoAlias", "");
+      const repoName = repoAlias !== "" ? repoAlias : workspaceFolder.name;
 
       // Get the file path relative to the repository root
       const relativeFilePath = path.relative(
@@ -31,8 +32,11 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       // Construct the Sourcegraph URL
-      const sourceGraphUrl = `https://${subdomain}.sourcegraph.com/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
 
+      // If the subdomain ends in a .com or similar domain ending, do not append .sourcegraph.com
+      const suffixes = [".net", ".com", ".org"];
+      const subdomainString = suffixes.some(suffix => subdomain.endsWith(suffix)) ? subdomain : `${subdomain}.sourcegraph.com`;
+      const sourceGraphUrl = `https://${subdomainString}/${basePath}/${repoName}/-/blob/${relativeFilePath}`;
       // Debugging: log the constructed URL
       console.log("SourceGraph URL:", sourceGraphUrl);
 


### PR DESCRIPTION
## Summary

Contributed by @aleggs (via fork of @214ko's fork):
- Adds `openInSourcegraph.repoAlias` setting — allows users to override the
repository name used in the Sourcegraph URL when it differs from the local    
workspace folder name                                                       
- Smarter subdomain handling — if the configured subdomain already ends in
`.com`, `.net`, or `.org`, the extension no longer appends `.sourcegraph.com`
(supports self-hosted instances with full domain names)